### PR TITLE
Corrected label categories count and fixed typo in documentation

### DIFF
--- a/HARDFORK-CHECKLIST.md
+++ b/HARDFORK-CHECKLIST.md
@@ -17,5 +17,5 @@
 ### Updates to the engine API
 
 - Add new endpoints to the `EngineApi` trait and implement endpoints.
-- Update the `ExceuctionPayload` + `ExecutionPayloadSidecar` to `Block` conversion if there are any additional parameters.
+- Update the `ExecutionPayload` + `ExecutionPayloadSidecar` to `Block` conversion if there are any additional parameters.
 - Update version specific validation checks in the `EngineValidator` trait.

--- a/docs/repo/labels.md
+++ b/docs/repo/labels.md
@@ -2,7 +2,7 @@
 
 Each label in the repository has a description attached that describes what the label means.
 
-There are 7 label categories in the repository:
+There are 8 label categories in the repository:
 
 - **Area labels**: These labels denote the general area of the project an issue or PR affects. These start with [`A-`][area].
 - **Category labels**: These labels denote the type of issue or change being made, for example https://github.com/paradigmxyz/reth/labels/C-bug or https://github.com/paradigmxyz/reth/labels/C-enhancement. These start with [`C-`][category].


### PR DESCRIPTION
1. Corrected the number of label categories in the repository documentation from 7 to 8.
2. Fixed the typo in `ExceutionPayload` to `ExecutionPayload`.