### PR TITLE
typo fix mdbx.h

### DIFF
--- a/crates/storage/libmdbx-rs/mdbx-sys/libmdbx/mdbx.h
+++ b/crates/storage/libmdbx-rs/mdbx-sys/libmdbx/mdbx.h
@@ -2246,7 +2246,7 @@ enum MDBX_option_t {
    * And for serie of lazy writes with flush is:
    *  latency = N * (emit + storage-execution) + flush + round-trip-to-storage.
    *
-   * So, for large N and/or noteable round-trip-to-storage the write+flush
+   * So, for large N and/or notable round-trip-to-storage the write+flush
    * approach is win. But for small N and/or near-zero NVMe-like latency
    * the write-through is better.
    *


### PR DESCRIPTION
# Pull Request Title  
**Fix Typo in `mdbx.h`**

## Description  
This pull request corrects a minor typo in the `mdbx.h` file, where the word "noteable" was updated to "notable" for improved spelling accuracy.

### Changes Made:
- **File Modified:** `crates/storage/libmdbx-rs/mdbx-sys/libmdbx/mdbx.h`
- **Summary of Changes:**  
  - Replaced "noteable" with "notable" in the comment.

## Checklist  
- [x] Corrected the typo in the comment.
- [x] Verified that no functionality or behavior was impacted by this change.

## Additional Notes  
This is a documentation change aimed at maintaining clarity and professionalism in the codebase.

---

**Allow edits by maintainers:** [x]
